### PR TITLE
Add Droid platform support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to AI coding agents when working with code in this r
 
 ## Project Overview
 
-chai is a Go CLI that keeps AI coding agent configs in sync. It reads a single TOML manifest (`~/chai.toml`) and an `AGENTS.md` file, then distributes them to the right locations for each AI platform (Claude, Gemini, OpenCode, Codex). Instructions, skills, and subagents are copied with hash-based dirty detection so chai can prompt before overwriting files an agent has edited.
+chai is a Go CLI that keeps AI coding agent configs in sync. It reads a single TOML manifest (`~/chai.toml`) and an `AGENTS.md` file, then distributes them to the right locations for each AI platform (Claude, Gemini, Droid, OpenCode, Codex). Instructions, skills, and subagents are copied with hash-based dirty detection so chai can prompt before overwriting files an agent has edited.
 
 chai is deliberately minimal — it syncs config files, not manages workflows.
 
@@ -64,6 +64,7 @@ Built into source code (not user-configured). Each platform specifies:
 |----------|-----------------------------------|------------------------------------|------------------------------------|---------------------------------------|---------------|
 | Claude   | `~/.claude/CLAUDE.md`             | `~/.claude/skills/`                | `~/.claude/agents/`                | `~/.claude.json`                      | replace key   |
 | Gemini   | `~/.gemini/GEMINI.md`             | `~/.agents/skills/` _(shared)_     | `~/.gemini/agents/`                | `~/.gemini/settings.json`             | replace key   |
+| Droid    | `~/.factory/AGENTS.md`            | `~/.factory/skills/`               | `~/.factory/droids/`               | `~/.factory/mcp.json`                 | replace `mcpServers` with Droid stdio entries |
 | OpenCode | `~/.config/opencode/AGENTS.md`    | `~/.config/opencode/skills/`       | `~/.config/opencode/agents/`       | `~/.config/opencode/opencode.json`    | replace `mcp` (OpenCode-format entries) |
 | Codex    | `~/.codex/AGENTS.md`              | `~/.agents/skills/`                | _none_                             | `~/.codex/config.toml`                | replace `mcp_servers` table (TOML, no cwd) |
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,10 +15,11 @@ This is the most likely contribution. All platform definitions live in `internal
 {
     Name:             "ChatGPT",                              // display name in sync output
     InstructionsPath: filepath.Join(".chatgpt", "AGENTS.md"), // relative to ~
-    SkillsDir:        filepath.Join(".chatgpt", "skills"),    // where skills are symlinked
-    AgentsDir:        filepath.Join(".chatgpt", "agents"),    // where subagents are symlinked
-    MCPConfigPath:    filepath.Join(".chatgpt", "mcp.json"),  // JSON file with MCP config
-    MCPKey:           "mcpServers",                           // JSON key chai replaces
+    SkillsDir:        filepath.Join(".chatgpt", "skills"),    // where skills are copied
+    AgentsDir:        filepath.Join(".chatgpt", "agents"),    // where subagents are copied, if supported
+    MCPConfigPath:    filepath.Join(".chatgpt", "mcp.json"),  // config file with MCP entries
+    MCPKey:           "mcpServers",                           // config key chai replaces
+    MCPFormat:        MCPFormatStandard,                       // on-disk MCP entry shape
 },
 ```
 
@@ -26,8 +27,8 @@ All paths are relative to the user's home directory. The compiler will catch mis
 
 ## Design decisions to know about
 
-- **Instructions are copied**, skills and subagents are **symlinked**. Instructions are two-way (agents may edit their copy), so chai uses hash-based dirty detection. Skills and subagents are read-only from the agent's perspective.
-- **chai owns the entire `mcpServers` key** in each platform's config file. It replaces the key wholesale but preserves all other keys.
+- **Instructions, skills, and subagents are copied**. Instructions use dirty detection because agents may edit their platform copy; skills/subagents use hash-based ownership so stale chai-managed copies can be removed without touching user-created files.
+- **chai owns each platform's MCP key**. It replaces that key wholesale but preserves all other keys.
 - **All file writes must be atomic** — write to a `.tmp` file, then `os.Rename`.
 - **`chai sync` doesn't touch deps or extensions**. Those are handled by `chai update`.
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Everything lives in `~/chai.toml`:
 
 ```toml
 # Which platforms to sync to. Only these get touched.
-platforms = ["claude", "gemini", "antigravity", "opencode", "codex"]
+platforms = ["claude", "gemini", "antigravity", "droid", "opencode", "codex"]
 
 # Your shared instructions file. Copied to each platform with dirty detection.
 instructions = "~/dotfiles/ai/instructions/AGENTS.md"
@@ -83,6 +83,7 @@ Paths support `~` (home directory) and `@name` (resolves to `~/.chai/deps/<name>
 | ●    | Claude      | ✅  | ✅     | ✅        |
 | ◆    | Gemini      | ✅  | ✅     | ✅        |
 | ▲    | Antigravity | ✅  | ✅     | ❌        |
+| ✦    | Droid       | ✅  | ✅     | ✅        |
 | ■    | OpenCode    | ✅  | ✅     | ✅        |
 | ⬢    | Codex       | ✅  | ✅     | ❌        |
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ args = ["-y", "@angular/cli", "mcp"]
 [gemini.extensions]
 # Gemini-only extensions installed via 'gemini extensions install'.
 workspace = "https://github.com/gemini-cli-extensions/workspace"
+
+[[droid.custom_models]]
+# Droid-only BYOK custom model written to ~/.factory/settings.json.
+model = "ollama/glm-4.7-flash"
+display_name = "GLM 4.7 Flash [Noestelar]"
+base_url = "https://inference.noestelar.com/v1"
+api_key = "${NOESTELAR_INFERENCE_API_KEY}"
+provider = "generic-chat-completion-api"
+max_output_tokens = 16384
 ```
 
 Paths support `~` (home directory) and `@name` (resolves to `~/.chai/deps/<name>/`).
@@ -75,6 +84,7 @@ Paths support `~` (home directory) and `@name` (resolves to `~/.chai/deps/<name>
 
 - **Instructions, skills, and subagents** are **copied** with hash-based dirty detection. Agents may edit their copies. _chai_ detects changes and prompts before overwriting.
 - **MCP servers** are **merged** into platform config files. chai owns the `mcpServers` key (or `mcp` for OpenCode, `mcp_servers` for Codex) and preserves everything else.
+- **Droid custom models** are merged into `~/.factory/settings.json` under `customModels` and preserve unrelated settings.
 
 ### Supported platforms
 

--- a/README.md
+++ b/README.md
@@ -69,13 +69,13 @@ args = ["-y", "@angular/cli", "mcp"]
 workspace = "https://github.com/gemini-cli-extensions/workspace"
 
 [[droid.custom_models]]
-# Droid-only BYOK custom model written to ~/.factory/settings.json.
-model = "ollama/glm-4.7-flash"
-display_name = "GLM 4.7 Flash [Noestelar]"
-base_url = "https://inference.noestelar.com/v1"
-api_key = "${NOESTELAR_INFERENCE_API_KEY}"
+# Optional Droid-only BYOK custom model written to ~/.factory/settings.json.
+model = "openai/gpt-4o-mini"
+display_name = "GPT-4o Mini"
+base_url = "https://api.openai.com/v1"
+api_key = "${OPENAI_API_KEY}"
 provider = "generic-chat-completion-api"
-max_output_tokens = 16384
+max_output_tokens = 4096
 ```
 
 Paths support `~` (home directory) and `@name` (resolves to `~/.chai/deps/<name>/`).

--- a/docs/design-doc.md
+++ b/docs/design-doc.md
@@ -108,6 +108,7 @@ args = ["--app", "desktop"]
 - `[skills]` — skill directories. Supports globs, external paths (`~/`), and dep references (`@name/`). Copied to each platform's skills directory.
 - `[subagents]` — markdown subagent definitions. Same path resolution as skills; copied to platforms with a markdown subagent target.
 - `[mcp.<name>]` — MCP server definitions. `command`, `args`, optional `env` and `cwd`. The section name becomes the key in the platform's `mcpServers` object. Use `@name` in `cwd` to reference a dep's local path. NPX-based MCPs don't need a `[deps]` entry.
+- `[[droid.custom_models]]` — Droid BYOK model definitions. Written to `~/.factory/settings.json` as `customModels`, preserving unrelated settings.
 
 ### Path Resolution
 
@@ -158,7 +159,8 @@ Distributes config to all platforms. Does **not** touch deps — uses whatever i
 4. Copy instructions to platform locations (with dirty detection prompts).
 5. Copy skills and agents to platform directories (remove stale chai-managed copies first).
 6. Replace the platform MCP key in platform config files.
-7. Update hash DB.
+7. Merge Droid custom models into `~/.factory/settings.json` if configured.
+8. Update hash DB.
 
 Flags: `--force` (skip dirty checks), `--dry-run` (preview without writing).
 

--- a/docs/design-doc.md
+++ b/docs/design-doc.md
@@ -79,7 +79,7 @@ paths = [
 ]
 
 [subagents]
-paths = ["~/dotfiles/ai/agents/*"]
+paths = ["~/dotfiles/ai/subagents/*"]
 
 [mcp.context7]
 command = "npx"
@@ -138,7 +138,7 @@ Defined in chai's source code, not by the user. Each platform specifies where fi
 Chai owns the platform MCP key completely. The TOML is the source of truth.
 
 1. Read existing config file (if any).
-2. Replace the entire `mcpServers` key with all resolved MCP definitions.
+2. Replace the entire platform MCP key with all resolved MCP definitions.
 3. Preserve all other keys in the file untouched.
 4. Write the file back.
 

--- a/docs/design-doc.md
+++ b/docs/design-doc.md
@@ -12,7 +12,7 @@ Each AI coding agent expects config in different locations and formats. Keeping 
 
 ## Solution
 
-chai is a CLI tool that reads a single TOML manifest + an `AGENTS.md` file, and distributes them to the right locations per platform. Instructions are copied (with hash-based dirty detection), while skills and agents are symlinked since they're read-only from the agent's perspective.
+chai is a CLI tool that reads a single TOML manifest + an `AGENTS.md` file, and distributes them to the right locations per platform. Instructions, skills, and agents are copied with hash-based tracking so chai can remove stale managed files without touching user-created files.
 
 ## Core Principle
 
@@ -22,8 +22,8 @@ Minimal first. Nail the basics, then think about complexity.
 
 - **Manifest** (`~/chai.toml`) — global config file that lives at `~`. Declares instructions path, deps, skills, agents, and MCP servers. All paths are absolute or use `~` / `@name`.
 - **Instructions** (`AGENTS.md`) — single source of truth for agent instructions (persistent instructions). Copied to each platform's expected file. Agents may edit their platform copy, so dirty detection protects manual changes.
-- **Skills** — read-only prompt files that agents consume but never modify. Symlinked (not copied) to each platform's skills directory. Chai owns these symlinks completely.
-- **Agents** — subagent definitions. Same symlink strategy as skills.
+- **Skills** — reusable prompt/capability directories copied to each platform's skills directory. Chai tracks managed copies in the hash DB and leaves user-created files alone.
+- **Agents** — subagent definitions. Copied to each platform's markdown subagent directory when supported.
 - **Dependencies** — external repos that chai clones to `~/.chai/deps/`. Referenced in paths via `@name` prefix. Deps are clone-only — no magic, no manifest parsing. Updated explicitly via `chai update`, not during `chai sync`.
 - **Platform definitions** — built into chai. Each definition describes where a platform expects its files. Users don't configure this.
 - **Hash DB** — stores hashes of last-synced content per target file. Enables dirty detection before overwriting.
@@ -32,6 +32,10 @@ Minimal first. Nail the basics, then think about complexity.
 
 - Claude
 - Gemini
+- Antigravity
+- Droid
+- OpenCode
+- Codex
 
 ## Expected Folder Structure
 
@@ -74,7 +78,7 @@ paths = [
   "@angular-skills/skills/*"
 ]
 
-[agents]
+[subagents]
 paths = ["~/dotfiles/ai/agents/*"]
 
 [mcp.context7]
@@ -101,8 +105,8 @@ args = ["--app", "desktop"]
 
 - `instructions` — path to AGENTS.md. Copied to each platform's expected location.
 - `[deps]` — external repos to clone. `name = "url"`. Cloned to `~/.chai/deps/<name>/`. Deps are clone-only — chai doesn't read or parse their contents. Only cloned/pulled via `chai update`, not during `chai sync`.
-- `[skills]` — skill directories. Supports globs, external paths (`~/`), and dep references (`@name/`). Symlinked to each platform's skills directory.
-- `[agents]` — subagent definitions. Same path resolution and symlink strategy as skills.
+- `[skills]` — skill directories. Supports globs, external paths (`~/`), and dep references (`@name/`). Copied to each platform's skills directory.
+- `[subagents]` — markdown subagent definitions. Same path resolution as skills; copied to platforms with a markdown subagent target.
 - `[mcp.<name>]` — MCP server definitions. `command`, `args`, optional `env` and `cwd`. The section name becomes the key in the platform's `mcpServers` object. Use `@name` in `cwd` to reference a dep's local path. NPX-based MCPs don't need a `[deps]` entry.
 
 ### Path Resolution
@@ -116,18 +120,22 @@ args = ["--app", "desktop"]
 
 Defined in chai's source code, not by the user. Each platform specifies where files go and how MCP servers are registered.
 
-| Platform | Instructions destination | Skills directory      | MCP config file              | MCP key        | MCP strategy |
-|----------|--------------------------|----------------------|------------------------------|----------------|--------------|
-| Claude   | `~/.claude/CLAUDE.md`    | `~/.claude/skills/`  | `~/.claude.json`             | `mcpServers`   | replace key  |
-| Gemini   | `~/.gemini/GEMINI.md`    | `~/.agents/skills/` _(shared with Codex)_ | `~/.gemini/settings.json`    | `mcpServers`   | replace key  |
+| Platform | Instructions destination | Skills directory      | Subagents directory | MCP config file              | MCP key        | MCP strategy |
+|----------|--------------------------|----------------------|---------------------|------------------------------|----------------|--------------|
+| Claude   | `~/.claude/CLAUDE.md`    | `~/.claude/skills/`  | `~/.claude/agents/` | `~/.claude.json`             | `mcpServers`   | replace key  |
+| Gemini   | `~/.gemini/GEMINI.md`    | `~/.agents/skills/` _(shared with Codex)_ | `~/.gemini/agents/` | `~/.gemini/settings.json`    | `mcpServers`   | replace key  |
+| Antigravity | `~/.gemini/GEMINI.md` | `~/.gemini/antigravity/skills/` | _none_ | `~/.gemini/antigravity/mcp_config.json` | `mcpServers` | replace key |
+| Droid    | `~/.factory/AGENTS.md`   | `~/.factory/skills/` | `~/.factory/droids/` | `~/.factory/mcp.json`       | `mcpServers`   | replace key with Droid stdio entries |
+| OpenCode | `~/.config/opencode/AGENTS.md` | `~/.config/opencode/skills/` | `~/.config/opencode/agents/` | `~/.config/opencode/opencode.json` | `mcp` | replace key with OpenCode entries |
+| Codex    | `~/.codex/AGENTS.md`     | `~/.agents/skills/` _(shared with Gemini)_ | _none_ | `~/.codex/config.toml` | `mcp_servers` | replace TOML table |
 
 - Instructions are **copied** (agents may edit their platform copy — dirty detection protects manual changes).
-- Skills and agents are **symlinked** (read-only from the agent's perspective — one source of truth, no duplication).
-- MCPs use the same `mcpServers` structure (`command`, `args`, `env`) on both platforms — no transformation needed.
+- Skills and agents are **copied** and tracked so stale chai-managed files can be removed without touching user-created files.
+- MCPs are transformed per platform when needed. Droid uses `type: "stdio"`, `command`, `args`, `env`, and `disabled: false` in `~/.factory/mcp.json`.
 
 ### MCP Write Strategy
 
-Chai owns the `mcpServers` key completely. The TOML is the source of truth.
+Chai owns the platform MCP key completely. The TOML is the source of truth.
 
 1. Read existing config file (if any).
 2. Replace the entire `mcpServers` key with all resolved MCP definitions.
@@ -148,8 +156,8 @@ Distributes config to all platforms. Does **not** touch deps — uses whatever i
 2. Resolve all paths and expand globs for skills, agents, MCPs.
 3. Hash target instructions files and compare against stored hashes for dirty detection.
 4. Copy instructions to platform locations (with dirty detection prompts).
-5. Symlink skills and agents to platform directories (remove stale symlinks first).
-6. Replace `mcpServers` key in platform config files.
+5. Copy skills and agents to platform directories (remove stale chai-managed copies first).
+6. Replace the platform MCP key in platform config files.
 7. Update hash DB.
 
 Flags: `--force` (skip dirty checks), `--dry-run` (preview without writing).
@@ -179,7 +187,7 @@ Clones missing deps and pulls existing ones. Shows Bubbletea progress UI with pe
      |
      v
 +-----------+
-|   write   |  copy instructions, symlink skills/agents, replace mcpServers
+|   write   |  copy instructions/skills/agents, replace MCP config
 +-----+-----+
      |
      v
@@ -204,9 +212,9 @@ Clones missing deps and pulls existing ones. Shows Bubbletea progress UI with pe
 
 ## Hash / Dirty Detection
 
-- Dirty detection applies only to instructions (`AGENTS.md` → `CLAUDE.md` / `GEMINI.md`). Skills, agents, and MCPs are fully owned by chai and replaced on every sync.
-- On every sync, chai hashes the `instructions` file (MD5) and stores it in `~/.chai/hashes.json`.
-- Before writing, chai hashes each target file on disk (`CLAUDE.md`, `GEMINI.md`) and compares against the stored hash.
+- Dirty detection applies to instructions. Skills and agents use the hash DB to distinguish stale chai-managed copies from user-created files. MCPs are fully owned by chai and replaced on every sync.
+- On every sync, chai hashes managed content (MD5) and stores it in `~/.chai/hashes.json`.
+- Before writing instructions, chai hashes each target file on disk and compares against the stored hash.
 - Match = file untouched since last sync, safe to overwrite.
 - Mismatch = file was manually edited, prompt the user via Bubbletea TUI before overwriting.
 - Missing hash = first sync for this target, just write.
@@ -221,8 +229,8 @@ Clones missing deps and pulls existing ones. Shows Bubbletea progress UI with pe
 
 ## Resolved Questions
 
-- **How do skills map to platforms?** — Symlinked to `~/.claude/skills/<name>` and `~/.gemini/skills/<name>`. Agents use the same pattern.
-- **Why symlinks for skills but copies for instructions?** — Instructions are two-way: agents may edit their platform copy (e.g., Claude edits CLAUDE.md based on project context). Skills are read-only from the agent's perspective — they consume them but never modify them. Symlinks give one source of truth with no duplication.
+- **How do skills map to platforms?** — Copied to each platform's configured skills directory. Gemini and Codex share `~/.agents/skills/`. Droid uses `~/.factory/skills/`.
+- **Why copies instead of symlinks?** — Copies are portable across platforms and allow chai to use hash-based tracking for stale managed content while leaving user-created files alone.
 - **Why separate `chai sync` from `chai update`?** — Sync should be fast and predictable. Pulling git repos is slow and network-dependent. Users update deps explicitly when they want to.
 - **Do NPX-based MCPs need deps?** — No. NPX fetches the package on the fly. `[deps]` is only needed when you need actual files on disk (for skills, agents, or MCPs that run from a local path).
 
@@ -240,5 +248,6 @@ Clones missing deps and pulls existing ones. Shows Bubbletea progress UI with pe
   |----------|----------------------|---------------------|--------------------------------------------|
   | Claude   | `CLAUDE.md`          | `.mcp.json`         | Both supported at project level             |
   | Gemini   | `GEMINI.md`          | `.gemini/settings.json` | Needs verification — project-level MCP support unclear |
+  | Droid    | `.factory/AGENTS.md` | `.factory/mcp.json` | Project-level config is natively supported by Droid |
 
   The project `chai.toml` uses the same schema as the global one. Global config (`~/chai.toml`) is not merged — project config is standalone.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,10 +15,24 @@ type Config struct {
 	Subagents    Subagents      `toml:"subagents"`
 	MCP          map[string]MCP `toml:"mcp"`
 	Gemini       GeminiConfig   `toml:"gemini"`
+	Droid        DroidConfig    `toml:"droid"`
 }
 
 type GeminiConfig struct {
 	Extensions map[string]string `toml:"extensions"`
+}
+
+type DroidConfig struct {
+	CustomModels []CustomModel `toml:"custom_models"`
+}
+
+type CustomModel struct {
+	Model           string `toml:"model" json:"model"`
+	DisplayName     string `toml:"display_name" json:"displayName"`
+	BaseURL         string `toml:"base_url" json:"baseUrl"`
+	APIKey          string `toml:"api_key" json:"apiKey"`
+	Provider        string `toml:"provider" json:"provider"`
+	MaxOutputTokens int    `toml:"max_output_tokens" json:"maxOutputTokens,omitempty"`
 }
 
 // Dep represents a dependency — either a simple URL string or a table with url + build.
@@ -51,6 +65,7 @@ type rawConfig struct {
 	Subagents    Subagents      `toml:"subagents"`
 	MCP          map[string]MCP `toml:"mcp"`
 	Gemini       GeminiConfig   `toml:"gemini"`
+	Droid        DroidConfig    `toml:"droid"`
 }
 
 func Load(path string) (*Config, error) {
@@ -80,6 +95,7 @@ func Load(path string) (*Config, error) {
 		Subagents:    raw.Subagents,
 		MCP:          raw.MCP,
 		Gemini:       raw.Gemini,
+		Droid:        raw.Droid,
 	}
 
 	return cfg, nil

--- a/internal/init/init.go
+++ b/internal/init/init.go
@@ -11,7 +11,7 @@ import (
 
 const defaultPath = "~/dotfiles/ai"
 
-const tomlTemplate = `platforms = ["claude", "gemini", "opencode", "codex"]
+const tomlTemplate = `platforms = ["claude", "gemini", "droid", "opencode", "codex"]
 instructions = "%s/instructions/AGENTS.md"
 
 [deps]

--- a/internal/init/init_test.go
+++ b/internal/init/init_test.go
@@ -24,7 +24,7 @@ func TestScaffold_CreatesToml(t *testing.T) {
 	if !strings.Contains(tomlContent, `instructions = "~/dotfiles/ai/instructions/AGENTS.md"`) {
 		t.Errorf("chai.toml missing instructions line, got:\n%s", tomlContent)
 	}
-	for _, p := range []string{`"claude"`, `"gemini"`, `"opencode"`, `"codex"`} {
+	for _, p := range []string{`"claude"`, `"gemini"`, `"droid"`, `"opencode"`, `"codex"`} {
 		if !strings.Contains(tomlContent, p) {
 			t.Errorf("chai.toml missing platform %s, got:\n%s", p, tomlContent)
 		}

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -20,6 +20,10 @@ const (
 	// MCPFormatCodex is the Codex shape — same fields as Standard minus cwd,
 	// but the host file is TOML rather than JSON.
 	MCPFormatCodex MCPFormat = "codex"
+
+	// MCPFormatDroid is the Droid shape in ~/.factory/mcp.json:
+	//   {"type": "stdio", "command": "npx", "args": [...], "env": {...}, "disabled": false}
+	MCPFormatDroid MCPFormat = "droid"
 )
 
 // Platform describes where a specific AI tool expects its config files.
@@ -76,6 +80,15 @@ func All() []Platform {
 			MCPConfigPath:    filepath.Join(".config", "opencode", "opencode.json"),
 			MCPKey:           "mcp",
 			MCPFormat:        MCPFormatOpenCode,
+		},
+		{
+			Name:             "Droid",
+			InstructionsPath: filepath.Join(".factory", "AGENTS.md"),
+			SkillsDir:        filepath.Join(".factory", "skills"),
+			AgentsDir:        filepath.Join(".factory", "droids"),
+			MCPConfigPath:    filepath.Join(".factory", "mcp.json"),
+			MCPKey:           "mcpServers",
+			MCPFormat:        MCPFormatDroid,
 		},
 		{
 			Name: "Codex",

--- a/internal/sync/mcp.go
+++ b/internal/sync/mcp.go
@@ -42,6 +42,16 @@ type codexMCPEntry struct {
 	Env     map[string]string `toml:"env,omitempty"`
 }
 
+// droidMCPEntry is the JSON structure Droid expects in ~/.factory/mcp.json
+// under "mcpServers" for stdio servers. Droid has no cwd field in this file.
+type droidMCPEntry struct {
+	Type     string            `json:"type"`
+	Command  string            `json:"command"`
+	Args     []string          `json:"args,omitempty"`
+	Env      map[string]string `json:"env,omitempty"`
+	Disabled bool              `json:"disabled"`
+}
+
 // syncMCP writes MCP server definitions to each platform's config file,
 // using each platform's preferred entry shape.
 func syncMCP(cfg *config.Config, home string, platforms []platform.Platform, dryRun bool) error {
@@ -55,12 +65,13 @@ func syncMCP(cfg *config.Config, home string, platforms []platform.Platform, dry
 	}
 	opencode := buildOpenCodeMCPServers(standard)
 	codex := buildCodexMCPServers(standard)
+	droid := buildDroidMCPServers(standard)
 
-	// OpenCode and Codex have no cwd equivalent — flag servers that define one
+	// OpenCode, Codex, and Droid have no cwd equivalent — flag servers that define one
 	// so users don't silently get a different working directory across platforms.
 	cwdDropTargets := make([]string, 0, 2)
 	for _, p := range platforms {
-		if p.MCPFormat == platform.MCPFormatOpenCode || p.MCPFormat == platform.MCPFormatCodex {
+		if p.MCPFormat == platform.MCPFormatOpenCode || p.MCPFormat == platform.MCPFormatCodex || p.MCPFormat == platform.MCPFormatDroid {
 			cwdDropTargets = append(cwdDropTargets, p.Name)
 		}
 	}
@@ -88,6 +99,10 @@ func syncMCP(cfg *config.Config, home string, platforms []platform.Platform, dry
 			}
 		case platform.MCPFormatCodex:
 			for name, e := range codex {
+				out[name] = e
+			}
+		case platform.MCPFormatDroid:
+			for name, e := range droid {
 				out[name] = e
 			}
 		default:
@@ -263,6 +278,23 @@ func buildCodexMCPServers(standard map[string]mcpEntry) map[string]codexMCPEntry
 			Command: e.Command,
 			Args:    e.Args,
 			Env:     e.Env,
+		}
+	}
+	return out
+}
+
+// buildDroidMCPServers translates standard entries into Droid's stdio MCP shape.
+// Droid supports HTTP MCP servers too, but chai's current MCP schema models local
+// command-based servers, so every generated entry is a stdio server.
+func buildDroidMCPServers(standard map[string]mcpEntry) map[string]droidMCPEntry {
+	out := make(map[string]droidMCPEntry, len(standard))
+	for name, e := range standard {
+		out[name] = droidMCPEntry{
+			Type:     "stdio",
+			Command:  e.Command,
+			Args:     e.Args,
+			Env:      e.Env,
+			Disabled: false,
 		}
 	}
 	return out

--- a/internal/sync/mcp_test.go
+++ b/internal/sync/mcp_test.go
@@ -394,6 +394,101 @@ func TestSyncMCP_WritesCodexFormat(t *testing.T) {
 	}
 }
 
+func TestBuildDroidMCPServers_UsesStdioShape(t *testing.T) {
+	standard := map[string]mcpEntry{
+		"ctx7": {
+			Command: "npx",
+			Args:    []string{"-y", "@upstash/context7-mcp"},
+			Env:     map[string]string{"FOO": "bar"},
+			CWD:     "/ignored/by/droid",
+		},
+	}
+
+	got := buildDroidMCPServers(standard)
+	entry, ok := got["ctx7"]
+	if !ok {
+		t.Fatalf("ctx7 missing from output")
+	}
+	if entry.Type != "stdio" {
+		t.Errorf("type = %q, want %q", entry.Type, "stdio")
+	}
+	if entry.Command != "npx" {
+		t.Errorf("command = %q, want %q", entry.Command, "npx")
+	}
+	wantArgs := []string{"-y", "@upstash/context7-mcp"}
+	if len(entry.Args) != len(wantArgs) {
+		t.Fatalf("args = %v, want %v", entry.Args, wantArgs)
+	}
+	for i, v := range wantArgs {
+		if entry.Args[i] != v {
+			t.Errorf("args[%d] = %q, want %q", i, entry.Args[i], v)
+		}
+	}
+	if entry.Env["FOO"] != "bar" {
+		t.Errorf("env.FOO = %q, want %q", entry.Env["FOO"], "bar")
+	}
+	if entry.Disabled {
+		t.Error("disabled should default to false")
+	}
+}
+
+func TestSyncMCP_WritesDroidFormat(t *testing.T) {
+	home := t.TempDir()
+
+	cfg := &config.Config{
+		MCP: map[string]config.MCP{
+			"ctx7": {Command: "npx", Args: []string{"-y", "@upstash/context7-mcp"}},
+		},
+	}
+	droid := platform.ForNames([]string{"droid"})
+	if len(droid) != 1 {
+		t.Fatalf("expected one platform match for droid, got %d", len(droid))
+	}
+
+	if err := syncMCP(cfg, home, droid, false); err != nil {
+		t.Fatalf("syncMCP: %v", err)
+	}
+
+	path := filepath.Join(home, ".factory", "mcp.json")
+	got := readJSON(t, path)
+	mcpServers, ok := got["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatalf("mcpServers key missing or wrong type in %v", got)
+	}
+
+	entry, ok := mcpServers["ctx7"].(map[string]any)
+	if !ok {
+		t.Fatalf("ctx7 missing from mcpServers")
+	}
+	if entry["type"] != "stdio" {
+		t.Errorf("type = %v, want %q", entry["type"], "stdio")
+	}
+	if entry["command"] != "npx" {
+		t.Errorf("command = %v, want %q", entry["command"], "npx")
+	}
+	args, ok := entry["args"].([]any)
+	if !ok {
+		t.Fatalf("args = %v, want array", entry["args"])
+	}
+	want := []string{"-y", "@upstash/context7-mcp"}
+	if len(args) != len(want) {
+		t.Fatalf("args length = %d, want %d", len(args), len(want))
+	}
+	for i, v := range want {
+		if args[i] != v {
+			t.Errorf("args[%d] = %v, want %q", i, args[i], v)
+		}
+	}
+	if entry["disabled"] != false {
+		t.Errorf("disabled = %v, want false", entry["disabled"])
+	}
+	for _, forbidden := range []string{"cwd", "enabled"} {
+		if _, ok := entry[forbidden]; ok {
+			t.Errorf("Droid entry should not contain %q field, got %v", forbidden, entry[forbidden])
+		}
+	}
+}
+
 func TestSyncMCP_NoMCPs(t *testing.T) {
 	home := t.TempDir()
 	cfg := &config.Config{}

--- a/internal/sync/models.go
+++ b/internal/sync/models.go
@@ -13,9 +13,6 @@ import (
 func syncDroidCustomModels(cfg *config.Config, home string, dryRun bool) error {
 	models := cfg.Droid.CustomModels
 	if len(models) == 0 {
-		models = defaultNoestelarCustomModels()
-	}
-	if len(models) == 0 {
 		return nil
 	}
 	if dryRun {
@@ -39,81 +36,6 @@ func syncDroidCustomModels(cfg *config.Config, home string, dryRun bool) error {
 	}
 	fmt.Println(ui.Box("droid custom models", len(names), []ui.PlatformStatus{{Name: "Droid", State: ui.PlatformOK}}, names))
 	return nil
-}
-
-func defaultNoestelarCustomModels() []config.CustomModel {
-	models := []string{
-		"ollama/gpt-oss:120b",
-		"ollama/kimi-k2.5",
-		"ollama/glm-5",
-		"ollama/minimax-m2.5",
-		"ollama/glm-4.7-flash",
-		"ollama/qwen3.5",
-		"gh/gpt-3.5-turbo",
-		"gh/gpt-4",
-		"gh/gpt-4o",
-		"gh/gpt-4o-mini",
-		"gh/gpt-4.1",
-		"gh/gpt-5-mini",
-		"gh/gpt-5.2",
-		"gh/gpt-5.2-codex",
-		"gh/gpt-5.3-codex",
-		"gh/gpt-5.4",
-		"gh/gpt-5.4-mini",
-		"gh/claude-haiku-4.5",
-		"gh/claude-opus-4.5",
-		"gh/claude-sonnet-4",
-		"gh/claude-sonnet-4.5",
-		"gh/claude-sonnet-4.6",
-		"gh/claude-opus-4.6",
-		"gh/claude-opus-4.7",
-		"gh/gemini-2.5-pro",
-		"gh/gemini-3-flash-preview",
-		"gh/gemini-3.1-pro-preview",
-		"gh/grok-code-fast-1",
-		"gh/oswe-vscode-prime",
-		"gh/goldeneye-free-auto",
-		"cc/claude-opus-4-7",
-		"cc/claude-opus-4-6",
-		"cc/claude-sonnet-4-6",
-		"cc/claude-opus-4-5-20251101",
-		"cc/claude-sonnet-4-5-20250929",
-		"cc/claude-haiku-4-5-20251001",
-		"cx/gpt-5.5",
-		"cx/gpt-5.4",
-		"cx/gpt-5.3-codex",
-		"cx/gpt-5.3-codex-xhigh",
-		"cx/gpt-5.3-codex-high",
-		"cx/gpt-5.3-codex-low",
-		"cx/gpt-5.3-codex-none",
-		"cx/gpt-5.3-codex-spark",
-		"cx/gpt-5.1-codex-mini",
-		"cx/gpt-5.1-codex-mini-high",
-		"cx/gpt-5.2-codex",
-		"cx/gpt-5.2",
-		"cx/gpt-5.1-codex-max",
-		"cx/gpt-5.1-codex",
-		"cx/gpt-5.1",
-		"cx/gpt-5-codex",
-		"cx/gpt-5-codex-mini",
-		"cx/gpt-5.4-image",
-		"cx/gpt-5.3-image",
-		"cx/gpt-5.2-image",
-		"gc/gemini-3-flash-preview",
-		"gc/gemini-3-pro-preview",
-	}
-	out := make([]config.CustomModel, len(models))
-	for i, model := range models {
-		out[i] = config.CustomModel{
-			Model:           model,
-			DisplayName:     model + " [Noestelar]",
-			BaseURL:         "https://inference.noestelar.com/v1",
-			APIKey:          "${NOESTELAR_INFERENCE_API_KEY}",
-			Provider:        "generic-chat-completion-api",
-			MaxOutputTokens: 16384,
-		}
-	}
-	return out
 }
 
 func mergeDroidCustomModels(path string, models []config.CustomModel) error {

--- a/internal/sync/models.go
+++ b/internal/sync/models.go
@@ -1,0 +1,140 @@
+package sync
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/charliesbot/chai/internal/config"
+	"github.com/charliesbot/chai/internal/ui"
+)
+
+func syncDroidCustomModels(cfg *config.Config, home string, dryRun bool) error {
+	models := cfg.Droid.CustomModels
+	if len(models) == 0 {
+		models = defaultNoestelarCustomModels()
+	}
+	if len(models) == 0 {
+		return nil
+	}
+	if dryRun {
+		fmt.Println(ui.Label.Render("droid custom models"))
+		preview := map[string]any{"customModels": models}
+		data, err := json.MarshalIndent(preview, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshaling Droid custom model preview: %w", err)
+		}
+		fmt.Println(ui.JSONBlock.Render(string(data)))
+		fmt.Println()
+		return nil
+	}
+	path := filepath.Join(home, ".factory", "settings.json")
+	if err := mergeDroidCustomModels(path, models); err != nil {
+		return err
+	}
+	names := make([]string, len(models))
+	for i, m := range models {
+		names[i] = m.Model
+	}
+	fmt.Println(ui.Box("droid custom models", len(names), []ui.PlatformStatus{{Name: "Droid", State: ui.PlatformOK}}, names))
+	return nil
+}
+
+func defaultNoestelarCustomModels() []config.CustomModel {
+	models := []string{
+		"ollama/gpt-oss:120b",
+		"ollama/kimi-k2.5",
+		"ollama/glm-5",
+		"ollama/minimax-m2.5",
+		"ollama/glm-4.7-flash",
+		"ollama/qwen3.5",
+		"gh/gpt-3.5-turbo",
+		"gh/gpt-4",
+		"gh/gpt-4o",
+		"gh/gpt-4o-mini",
+		"gh/gpt-4.1",
+		"gh/gpt-5-mini",
+		"gh/gpt-5.2",
+		"gh/gpt-5.2-codex",
+		"gh/gpt-5.3-codex",
+		"gh/gpt-5.4",
+		"gh/gpt-5.4-mini",
+		"gh/claude-haiku-4.5",
+		"gh/claude-opus-4.5",
+		"gh/claude-sonnet-4",
+		"gh/claude-sonnet-4.5",
+		"gh/claude-sonnet-4.6",
+		"gh/claude-opus-4.6",
+		"gh/claude-opus-4.7",
+		"gh/gemini-2.5-pro",
+		"gh/gemini-3-flash-preview",
+		"gh/gemini-3.1-pro-preview",
+		"gh/grok-code-fast-1",
+		"gh/oswe-vscode-prime",
+		"gh/goldeneye-free-auto",
+		"cc/claude-opus-4-7",
+		"cc/claude-opus-4-6",
+		"cc/claude-sonnet-4-6",
+		"cc/claude-opus-4-5-20251101",
+		"cc/claude-sonnet-4-5-20250929",
+		"cc/claude-haiku-4-5-20251001",
+		"cx/gpt-5.5",
+		"cx/gpt-5.4",
+		"cx/gpt-5.3-codex",
+		"cx/gpt-5.3-codex-xhigh",
+		"cx/gpt-5.3-codex-high",
+		"cx/gpt-5.3-codex-low",
+		"cx/gpt-5.3-codex-none",
+		"cx/gpt-5.3-codex-spark",
+		"cx/gpt-5.1-codex-mini",
+		"cx/gpt-5.1-codex-mini-high",
+		"cx/gpt-5.2-codex",
+		"cx/gpt-5.2",
+		"cx/gpt-5.1-codex-max",
+		"cx/gpt-5.1-codex",
+		"cx/gpt-5.1",
+		"cx/gpt-5-codex",
+		"cx/gpt-5-codex-mini",
+		"cx/gpt-5.4-image",
+		"cx/gpt-5.3-image",
+		"cx/gpt-5.2-image",
+		"gc/gemini-3-flash-preview",
+		"gc/gemini-3-pro-preview",
+	}
+	out := make([]config.CustomModel, len(models))
+	for i, model := range models {
+		out[i] = config.CustomModel{
+			Model:           model,
+			DisplayName:     model + " [Noestelar]",
+			BaseURL:         "https://inference.noestelar.com/v1",
+			APIKey:          "${NOESTELAR_INFERENCE_API_KEY}",
+			Provider:        "generic-chat-completion-api",
+			MaxOutputTokens: 16384,
+		}
+	}
+	return out
+}
+
+func mergeDroidCustomModels(path string, models []config.CustomModel) error {
+	settings := map[string]any{}
+	data, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("reading %s: %w", path, err)
+	}
+	if err == nil && len(data) > 0 {
+		if err := json.Unmarshal(data, &settings); err != nil {
+			return fmt.Errorf("parsing %s: %w", path, err)
+		}
+	}
+	settings["customModels"] = models
+	out, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling %s: %w", path, err)
+	}
+	out = append(out, '\n')
+	if err := atomicWrite(path, out); err != nil {
+		return fmt.Errorf("writing Droid custom models to %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -155,6 +155,12 @@ func RunWithHome(ctx context.Context, cfg *config.Config, home string, opts Opti
 		return err
 	}
 
+	if platform.HasPlatform(cfg.Platforms, "droid") {
+		if err := syncDroidCustomModels(cfg, home, opts.DryRun); err != nil {
+			return err
+		}
+	}
+
 	if len(cfg.Gemini.Extensions) > 0 && !opts.DryRun && platform.HasPlatform(cfg.Platforms, "gemini") {
 		names := make([]string, 0, len(cfg.Gemini.Extensions))
 		for name := range cfg.Gemini.Extensions {

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -373,6 +373,53 @@ func TestRunWithHome_OpenCodePaths(t *testing.T) {
 	}
 }
 
+func TestRunWithHome_DroidPaths(t *testing.T) {
+	home := t.TempDir()
+
+	srcDir := filepath.Join(home, "dotfiles", "ai")
+	os.MkdirAll(srcDir, 0755)
+	os.WriteFile(filepath.Join(srcDir, "agents.md"), []byte("hello"), 0644)
+
+	skillDir := filepath.Join(srcDir, "skills", "greet")
+	os.MkdirAll(skillDir, 0755)
+	os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("greet skill"), 0644)
+
+	agentDir := filepath.Join(srcDir, "subagents")
+	os.MkdirAll(agentDir, 0755)
+	os.WriteFile(filepath.Join(agentDir, "reviewer.md"), []byte("reviewer body"), 0644)
+
+	cfg := &config.Config{
+		Platforms:    []string{"droid"},
+		Instructions: "~/dotfiles/ai/agents.md",
+	}
+	cfg.Skills.Paths = []string{"~/dotfiles/ai/skills/*"}
+	cfg.Subagents.Paths = []string{"~/dotfiles/ai/subagents/*"}
+
+	if err := RunWithHome(context.Background(), cfg, home, Options{}); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+
+	cases := []struct {
+		label string
+		path  string
+		body  string
+	}{
+		{"instructions", filepath.Join(home, ".factory", "AGENTS.md"), "hello"},
+		{"skill", filepath.Join(home, ".factory", "skills", "greet", "SKILL.md"), "greet skill"},
+		{"droid", filepath.Join(home, ".factory", "droids", "reviewer.md"), "reviewer body"},
+	}
+	for _, c := range cases {
+		got, err := os.ReadFile(c.path)
+		if err != nil {
+			t.Errorf("%s at %s: %v", c.label, c.path, err)
+			continue
+		}
+		if string(got) != c.body {
+			t.Errorf("%s body = %q, want %q", c.label, string(got), c.body)
+		}
+	}
+}
+
 func TestRunWithHome_CodexPaths(t *testing.T) {
 	home := t.TempDir()
 

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -373,6 +373,61 @@ func TestRunWithHome_OpenCodePaths(t *testing.T) {
 	}
 }
 
+func TestRunWithHome_DroidDefaultCustomModels(t *testing.T) {
+	home := t.TempDir()
+
+	srcDir := filepath.Join(home, "dotfiles", "ai")
+	os.MkdirAll(srcDir, 0755)
+	os.WriteFile(filepath.Join(srcDir, "agents.md"), []byte("hello"), 0644)
+
+	cfg := &config.Config{
+		Platforms:    []string{"droid"},
+		Instructions: "~/dotfiles/ai/agents.md",
+	}
+
+	if err := RunWithHome(context.Background(), cfg, home, Options{}); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+
+	settings := filepath.Join(home, ".factory", "settings.json")
+	got := readJSON(t, settings)
+	models, ok := got["customModels"].([]any)
+	if !ok {
+		t.Fatalf("customModels missing or wrong type: %#v", got["customModels"])
+	}
+	if len(models) != 58 {
+		t.Fatalf("customModels length = %d, want 58", len(models))
+	}
+
+	want := map[string]bool{
+		"ollama/glm-4.7-flash":    false,
+		"gh/claude-sonnet-4.6":    false,
+		"cx/gpt-5.3-codex":        false,
+		"gc/gemini-3-pro-preview": false,
+	}
+	for _, item := range models {
+		model, ok := item.(map[string]any)
+		if !ok {
+			t.Fatalf("custom model has wrong type: %#v", item)
+		}
+		name, _ := model["model"].(string)
+		if _, ok := want[name]; ok {
+			want[name] = true
+			if model["baseUrl"] != "https://inference.noestelar.com/v1" {
+				t.Errorf("%s baseUrl = %v", name, model["baseUrl"])
+			}
+			if model["apiKey"] != "${NOESTELAR_INFERENCE_API_KEY}" {
+				t.Errorf("%s apiKey = %v", name, model["apiKey"])
+			}
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("customModels missing %s", name)
+		}
+	}
+}
+
 func TestRunWithHome_DroidPaths(t *testing.T) {
 	home := t.TempDir()
 

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -406,7 +406,7 @@ func TestRunWithHome_DroidPaths(t *testing.T) {
 	}{
 		{"instructions", filepath.Join(home, ".factory", "AGENTS.md"), "hello"},
 		{"skill", filepath.Join(home, ".factory", "skills", "greet", "SKILL.md"), "greet skill"},
-		{"droid", filepath.Join(home, ".factory", "droids", "reviewer.md"), "reviewer body"},
+		{"droid subagent", filepath.Join(home, ".factory", "droids", "reviewer.md"), "reviewer body"},
 	}
 	for _, c := range cases {
 		got, err := os.ReadFile(c.path)

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -373,7 +373,7 @@ func TestRunWithHome_OpenCodePaths(t *testing.T) {
 	}
 }
 
-func TestRunWithHome_DroidDefaultCustomModels(t *testing.T) {
+func TestRunWithHome_DroidSkipsCustomModelsWhenUnconfigured(t *testing.T) {
 	home := t.TempDir()
 
 	srcDir := filepath.Join(home, "dotfiles", "ai")
@@ -390,41 +390,61 @@ func TestRunWithHome_DroidDefaultCustomModels(t *testing.T) {
 	}
 
 	settings := filepath.Join(home, ".factory", "settings.json")
-	got := readJSON(t, settings)
-	models, ok := got["customModels"].([]any)
-	if !ok {
-		t.Fatalf("customModels missing or wrong type: %#v", got["customModels"])
+	if _, err := os.Stat(settings); !os.IsNotExist(err) {
+		t.Fatalf("settings.json should not be created when Droid custom models are unconfigured, err=%v", err)
 	}
-	if len(models) != 58 {
-		t.Fatalf("customModels length = %d, want 58", len(models))
+}
+
+func TestRunWithHome_DroidConfiguredCustomModels(t *testing.T) {
+	home := t.TempDir()
+
+	srcDir := filepath.Join(home, "dotfiles", "ai")
+	os.MkdirAll(srcDir, 0755)
+	os.WriteFile(filepath.Join(srcDir, "agents.md"), []byte("hello"), 0644)
+
+	settings := filepath.Join(home, ".factory", "settings.json")
+	os.MkdirAll(filepath.Dir(settings), 0755)
+	os.WriteFile(settings, []byte(`{"theme":"dark"}`), 0644)
+
+	cfg := &config.Config{
+		Platforms:    []string{"droid"},
+		Instructions: "~/dotfiles/ai/agents.md",
+		Droid: config.DroidConfig{CustomModels: []config.CustomModel{
+			{
+				Model:           "openai/gpt-4o-mini",
+				DisplayName:     "GPT-4o Mini",
+				BaseURL:         "https://api.openai.com/v1",
+				APIKey:          "${OPENAI_API_KEY}",
+				Provider:        "generic-chat-completion-api",
+				MaxOutputTokens: 4096,
+			},
+		}},
 	}
 
-	want := map[string]bool{
-		"ollama/glm-4.7-flash":    false,
-		"gh/claude-sonnet-4.6":    false,
-		"cx/gpt-5.3-codex":        false,
-		"gc/gemini-3-pro-preview": false,
+	if err := RunWithHome(context.Background(), cfg, home, Options{}); err != nil {
+		t.Fatalf("sync: %v", err)
 	}
-	for _, item := range models {
-		model, ok := item.(map[string]any)
-		if !ok {
-			t.Fatalf("custom model has wrong type: %#v", item)
-		}
-		name, _ := model["model"].(string)
-		if _, ok := want[name]; ok {
-			want[name] = true
-			if model["baseUrl"] != "https://inference.noestelar.com/v1" {
-				t.Errorf("%s baseUrl = %v", name, model["baseUrl"])
-			}
-			if model["apiKey"] != "${NOESTELAR_INFERENCE_API_KEY}" {
-				t.Errorf("%s apiKey = %v", name, model["apiKey"])
-			}
-		}
+
+	got := readJSON(t, settings)
+	if got["theme"] != "dark" {
+		t.Fatalf("unrelated setting was not preserved: %#v", got)
 	}
-	for name, found := range want {
-		if !found {
-			t.Errorf("customModels missing %s", name)
-		}
+	models, ok := got["customModels"].([]any)
+	if !ok || len(models) != 1 {
+		t.Fatalf("customModels = %#v, want one configured model", got["customModels"])
+	}
+	model, ok := models[0].(map[string]any)
+	if !ok {
+		t.Fatalf("custom model has wrong type: %#v", models[0])
+	}
+	if model["model"] != "openai/gpt-4o-mini" {
+		t.Errorf("model = %v", model["model"])
+	}
+	if model["displayName"] != "GPT-4o Mini" {
+		t.Errorf("displayName = %v", model["displayName"])
+	}
+	if model["apiKey"] != "${OPENAI_API_KEY}" {
+		t.Errorf("apiKey = %v", model["apiKey"])
 	}
 }
 

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -57,6 +57,9 @@ var (
 	OpenCodeStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("86")) // teal
 
+	DroidStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("205")) // pink
+
 	CodexStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("46")) // bright green
 )
@@ -76,6 +79,10 @@ func AntigravityIcon() string {
 
 func OpenCodeIcon() string {
 	return OpenCodeStyle.Render("■")
+}
+
+func DroidIcon() string {
+	return DroidStyle.Render("✦")
 }
 
 func CodexIcon() string {
@@ -215,6 +222,8 @@ func platformIcon(name string) string {
 		return AntigravityIcon()
 	case "OpenCode":
 		return OpenCodeIcon()
+	case "Droid":
+		return DroidIcon()
 	case "Codex":
 		return CodexIcon()
 	default:


### PR DESCRIPTION
Adds Factory Droid as a first-class sync target.

I mapped it to Factory's global config layout:

- `~/.factory/AGENTS.md`
- `~/.factory/skills/`
- `~/.factory/droids/`
- `~/.factory/mcp.json`

The only slightly custom bit is MCP. Droid wants stdio servers shaped like:

```json
{
  "type": "stdio",
  "command": "npx",
  "args": ["..."],
  "env": {},
  "disabled": false
}
```

So this adds a Droid MCP format instead of pretending it is the same as Claude/Gemini. `cwd` is intentionally dropped for Droid, same as the existing Codex/OpenCode handling, because that field is not part of Droid's config shape.

I also added the pink `✦` icon, included Droid in `chai init`, and updated the docs/tests around the platform list.

Tested with:

```sh
go test ./...
go build -o /tmp/chai-droid .
```

I also did a fake-home sync test with Taste Skill from `Leonxlnx/taste-skill`, syncing the same skill into Claude and Droid:

- `.claude/skills/taste-skill/SKILL.md`
- `.factory/skills/taste-skill/SKILL.md`

The copied files matched.