### PR TITLE
chore: distribute via brews formula instead of casks to prevent gatekeeper warnings

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,7 +25,7 @@ checksum:
 changelog:
   sort: asc
 
-homebrew_casks:
+brews:
   - repository:
       owner: charliesbot
       name: homebrew-tap

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Keep AI coding agent configs in sync. One manifest, distributed to every platfor
 ### Homebrew
 
 ```bash
-brew install --cask charliesbot/tap/chai
+brew install charliesbot/tap/chai
 ```
 
 ### Go


### PR DESCRIPTION
 Currently, when installing `chai` on macOS using the Homebrew Cask, macOS Gatekeeper blocks it because it downloads an unsigned precompiled binary and flags it as untrusted.

This PR switches the GoReleaser configuration from `homebrew_casks` to `brews`. This distributes the tool as a standard Homebrew Formula instead of a Cask, which avoids the macOS Gatekeeper block and fixes the installation warnings.

**Changes:**
    - `.goreleaser.yml`: changed `homebrew_casks` to `brews`
    - `README.md`: updated instructions from `brew install --cask ...` to `brew install ...`